### PR TITLE
fix: standardize operation action strings to follow documentation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,10 @@ When `Mittwald.node.ts` imports `'./resources/implementations/operations'`, all 
 
 - All available resources and operations should be documented in `README.md`.
 - Each operation should have a brief description of its purpose and parameters.
+- The operation `action` strings should follow the following requirements:
+  - Correct english grammar and spelling; start with a capital letter and a verb.
+  - Use "real" language, no API terminology or internal identifiers. For example, use `app installation` instead of `AppInstallation` or `app_installation`.
+  - Try to use domain-specific terminology where possible. For example, use `Uninstall app` instead of `Delete app installation`.
 
 ## Coding instructions
 

--- a/nodes/Mittwald/resources/implementations/App/operations/delete.ts
+++ b/nodes/Mittwald/resources/implementations/App/operations/delete.ts
@@ -3,8 +3,8 @@ import { appResource } from '../resource';
 
 export default appResource
 	.addOperation({
-		name: 'Remove',
-		action: 'Delete AppInstallation',
+		name: 'Uninstall',
+		action: 'Uninstall an app',
 	})
 	.withProperties({
 		appInstallation: appInstallationProperty,

--- a/nodes/Mittwald/resources/implementations/App/operations/install.ts
+++ b/nodes/Mittwald/resources/implementations/App/operations/install.ts
@@ -8,7 +8,7 @@ import Z from 'zod';
 export default appResource
 	.addOperation({
 		name: 'Install',
-		action: 'Install App',
+		action: 'Install an app',
 	})
 	.withProperties({
 		project: projectProperty,

--- a/nodes/Mittwald/resources/implementations/Contributor/operations/listIncomingInvoices.ts
+++ b/nodes/Mittwald/resources/implementations/Contributor/operations/listIncomingInvoices.ts
@@ -4,7 +4,7 @@ import { contributorResource } from '../resource';
 export default contributorResource
 	.addOperation({
 		name: 'List incoming invoices',
-		action: 'list incoming invoices',
+		action: 'List incoming invoices',
 	})
 	.withProperties({
 		organisation: organisationProperty,

--- a/nodes/Mittwald/resources/implementations/Contributor/operations/listOutgoingInvoices.ts
+++ b/nodes/Mittwald/resources/implementations/Contributor/operations/listOutgoingInvoices.ts
@@ -4,7 +4,7 @@ import { contributorResource } from '../resource';
 export default contributorResource
 	.addOperation({
 		name: 'List outgoing invoices',
-		action: 'list outgoing invoices',
+		action: 'List outgoing invoices',
 	})
 	.withProperties({
 		organisation: organisationProperty,

--- a/nodes/Mittwald/resources/implementations/Contributor/operations/listOwnExtensions.ts
+++ b/nodes/Mittwald/resources/implementations/Contributor/operations/listOwnExtensions.ts
@@ -4,7 +4,7 @@ import { contributorResource } from '../resource';
 export default contributorResource
 	.addOperation({
 		name: 'List own extensions',
-		action: 'list own extensions',
+		action: 'List own extensions',
 	})
 	.withProperties({
 		organisation: organisationProperty,

--- a/nodes/Mittwald/resources/implementations/Conversation/operations/create.ts
+++ b/nodes/Mittwald/resources/implementations/Conversation/operations/create.ts
@@ -5,7 +5,7 @@ import Z from 'zod';
 export default conversationResource
 	.addOperation({
 		name: 'Create',
-		action: 'Create a Ticket',
+		action: 'Create a ticket',
 	})
 	.withProperties({
 		conversationCategory: conversationCategoryProperty,

--- a/nodes/Mittwald/resources/implementations/Project/operations/create.ts
+++ b/nodes/Mittwald/resources/implementations/Project/operations/create.ts
@@ -5,7 +5,7 @@ import Z from 'zod';
 projectResource
 	.addOperation({
 		name: 'Create',
-		action: 'Create Project on Server',
+		action: 'Create a project on a server',
 	})
 	.withProperties({
 		server: serverProperty,

--- a/nodes/Mittwald/resources/implementations/Project/operations/delete.ts
+++ b/nodes/Mittwald/resources/implementations/Project/operations/delete.ts
@@ -4,7 +4,7 @@ import projectProperty from '../../shared/projectProperty';
 export default projectResource
 	.addOperation({
 		name: 'Remove',
-		action: 'Delete Project',
+		action: 'Delete a project',
 	})
 	.withProperties({
 		project: projectProperty,

--- a/nodes/Mittwald/resources/implementations/Project/operations/get.ts
+++ b/nodes/Mittwald/resources/implementations/Project/operations/get.ts
@@ -3,7 +3,7 @@ import { projectResource } from '../resource';
 export default projectResource
 	.addOperation({
 		name: 'Get',
-		action: 'Get a Project',
+		action: 'Get a project',
 	})
 	.withProperties({
 		projectId: {

--- a/nodes/Mittwald/resources/implementations/Project/operations/list.ts
+++ b/nodes/Mittwald/resources/implementations/Project/operations/list.ts
@@ -3,7 +3,7 @@ import { projectResource } from '../resource';
 export default projectResource
 	.addOperation({
 		name: 'List All',
-		action: 'List all Projects',
+		action: 'List all projects',
 	})
 	.withProperties({})
 	.withExecuteFn(async (context) => {

--- a/nodes/Mittwald/resources/implementations/ProjectInvite/operations/accept.ts
+++ b/nodes/Mittwald/resources/implementations/ProjectInvite/operations/accept.ts
@@ -4,7 +4,7 @@ import Z from 'zod';
 export default projectInviteResource
 	.addOperation({
 		name: 'Accept',
-		action: 'Accept a invite to a project',
+		action: 'Accept an invite to a project',
 	})
 	.withProperties({
 		projectInviteId: {

--- a/nodes/Mittwald/resources/implementations/Server/operations/get.ts
+++ b/nodes/Mittwald/resources/implementations/Server/operations/get.ts
@@ -3,7 +3,7 @@ import { serverResource } from '../resource';
 export default serverResource
 	.addOperation({
 		name: 'Get',
-		action: 'Get a Server',
+		action: 'Get a server',
 	})
 	.withProperties({
 		serverId: {

--- a/nodes/Mittwald/resources/implementations/Server/operations/list.ts
+++ b/nodes/Mittwald/resources/implementations/Server/operations/list.ts
@@ -3,7 +3,7 @@ import { serverResource } from '../resource';
 export default serverResource
 	.addOperation({
 		name: 'List All',
-		action: 'List all Servers',
+		action: 'List all servers',
 	})
 	.withProperties({})
 	.withExecuteFn(async (context) => {


### PR DESCRIPTION
## Summary
- Update all 13 operation action strings to use proper English grammar and consistent formatting
- Add documentation guidelines for action strings in AGENTS.md
- Use domain-specific terminology (e.g., "Uninstall an app" instead of "Delete AppInstallation")

🤖 Generated with [Claude Code](https://claude.ai/code)