### PR TITLE
feat(project): add Get SSH User and Get SFTP User operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This node provides integration with the [mittwald API v2](https://developer.mitt
 - **Create an SFTP user**: Create an SFTP user for a project (parameters: Project, Name, Password, Access Level, Directories, optional Expires At)
 - **Delete an SSH user**: Delete an SSH user from a project (parameter: SSH User ID)
 - **Delete an SFTP user**: Delete an SFTP user from a project (parameter: SFTP User ID)
+- **Get an SSH user**: Get details of a specific SSH user (parameter: SSH User ID)
+- **Get an SFTP user**: Get details of a specific SFTP user (parameter: SFTP User ID)
 - **Delete a project**: Delete an existing project
 - **Get a project**: Get details of a specific project
 - **Get storage statistics**: Get storage usage statistics for a project

--- a/nodes/Mittwald/resources/implementations/Project/operations/getSftpUser.ts
+++ b/nodes/Mittwald/resources/implementations/Project/operations/getSftpUser.ts
@@ -1,0 +1,24 @@
+import { projectResource } from '../resource';
+
+export default projectResource
+	.addOperation({
+		name: 'Get SFTP User',
+		action: 'Get an SFTP user',
+		description: 'Get details of a specific SFTP user',
+	})
+	.withProperties({
+		sftpUserId: {
+			displayName: 'SFTP User ID',
+			type: 'string',
+			default: '',
+			required: true,
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { sftpUserId } = properties;
+
+		return apiClient.request({
+			path: `/sftp-users/${sftpUserId}`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Project/operations/getSshUser.ts
+++ b/nodes/Mittwald/resources/implementations/Project/operations/getSshUser.ts
@@ -1,0 +1,24 @@
+import { projectResource } from '../resource';
+
+export default projectResource
+	.addOperation({
+		name: 'Get SSH User',
+		action: 'Get an SSH user',
+		description: 'Get details of a specific SSH user',
+	})
+	.withProperties({
+		sshUserId: {
+			displayName: 'SSH User ID',
+			type: 'string',
+			default: '',
+			required: true,
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { sshUserId } = properties;
+
+		return apiClient.request({
+			path: `/ssh-users/${sshUserId}`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Project/operations/index.ts
+++ b/nodes/Mittwald/resources/implementations/Project/operations/index.ts
@@ -5,6 +5,8 @@ import './deleteSftpUser';
 import './deleteSshUser';
 import './delete';
 import './get';
+import './getSftpUser';
+import './getSshUser';
 import './getStorageStatistics';
 import './listMemberships';
 import './listSftpUsers';

--- a/test/integration/project.sftp-ssh-get.test.ts
+++ b/test/integration/project.sftp-ssh-get.test.ts
@@ -55,7 +55,7 @@ integrationDescribe('Project / SSH and SFTP User Get (integration)', () => {
 				resource: 'Project',
 				operation: 'Get SSH User',
 				parameters: {
-					sshUserId: fromStep('Create SSH User'),
+					sshUserId: fromStep('Create SSH User').value,
 				},
 			})
 			.run();
@@ -117,7 +117,7 @@ integrationDescribe('Project / SSH and SFTP User Get (integration)', () => {
 				resource: 'Project',
 				operation: 'Get SFTP User',
 				parameters: {
-					sftpUserId: fromStep('Create SFTP User'),
+					sftpUserId: fromStep('Create SFTP User').value,
 				},
 			})
 			.run();

--- a/test/integration/project.sftp-ssh-get.test.ts
+++ b/test/integration/project.sftp-ssh-get.test.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @n8n/community-nodes/no-restricted-imports */
+import { expect } from 'vitest';
+import { fromStep, runId } from './helpers';
+import { integrationDescribe, testcase } from './testcase';
+
+integrationDescribe('Project / SSH and SFTP User Get (integration)', () => {
+	testcase('creates and gets an SSH user', async (context) => {
+		const projectDescription = `it-${runId('ssh-get-project')}`;
+		const userDescription = `it-${runId('ssh-get-user')}`;
+		const password = `S3cure!${runId('pw')}`;
+
+		context.teardown(async () => {
+			const response = await context.mittwaldApi.project.listProjects();
+
+			if (response.status !== 200) {
+				throw new Error(`Failed to list projects during teardown: ${response.statusText}`);
+			}
+
+			const projects = response.data;
+
+			const project = projects.find(
+				(entry: { description?: string; id: string }) => entry.description === projectDescription,
+			);
+			if (project) {
+				await context.mittwaldApi.project.deleteProject({ projectId: project.id });
+			}
+		});
+
+		const result = await context
+			.scenario('SSH user get')
+			.step({
+				name: 'Create Project',
+				resource: 'Project',
+				operation: 'Create',
+				parameters: {
+					server: {
+						mode: 'id',
+						value: context.env.testServerId,
+					},
+					description: projectDescription,
+				},
+			})
+			.step({
+				name: 'Create SSH User',
+				resource: 'Project',
+				operation: 'Create SSH User',
+				parameters: {
+					project: fromStep('Create Project'),
+					description: userDescription,
+					password,
+				},
+			})
+			.step({
+				name: 'Get SSH User',
+				resource: 'Project',
+				operation: 'Get SSH User',
+				parameters: {
+					sshUserId: fromStep('Create SSH User'),
+				},
+			})
+			.run();
+
+		const sshUserId = result.step('Create SSH User').requireString('id');
+		expect(result.step('Get SSH User').requireString('id')).toBe(sshUserId);
+	});
+
+	testcase('creates and gets an SFTP user', async (context) => {
+		const projectDescription = `it-${runId('sftp-get-project')}`;
+		const userDescription = `it-${runId('sftp-get-user')}`;
+		const password = `S3cure!${runId('pw')}`;
+
+		context.teardown(async () => {
+			const response = await context.mittwaldApi.project.listProjects();
+
+			if (response.status !== 200) {
+				throw new Error(`Failed to list projects during teardown: ${response.statusText}`);
+			}
+
+			const projects = response.data;
+
+			const project = projects.find(
+				(entry: { description?: string; id: string }) => entry.description === projectDescription,
+			);
+			if (project) {
+				await context.mittwaldApi.project.deleteProject({ projectId: project.id });
+			}
+		});
+
+		const result = await context
+			.scenario('SFTP user get')
+			.step({
+				name: 'Create Project',
+				resource: 'Project',
+				operation: 'Create',
+				parameters: {
+					server: {
+						mode: 'id',
+						value: context.env.testServerId,
+					},
+					description: projectDescription,
+				},
+			})
+			.step({
+				name: 'Create SFTP User',
+				resource: 'Project',
+				operation: 'Create SFTP User',
+				parameters: {
+					project: fromStep('Create Project'),
+					description: userDescription,
+					password,
+					accessLevel: 'read',
+					directories: '/html',
+				},
+			})
+			.step({
+				name: 'Get SFTP User',
+				resource: 'Project',
+				operation: 'Get SFTP User',
+				parameters: {
+					sftpUserId: fromStep('Create SFTP User'),
+				},
+			})
+			.run();
+
+		const sftpUserId = result.step('Create SFTP User').requireString('id');
+		expect(result.step('Get SFTP User').requireString('id')).toBe(sftpUserId);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds **Get SFTP User** (`GET /v2/sftp-users/{sftpUserId}`) and **Get SSH User** (`GET /v2/ssh-users/{sshUserId}`) operations under the existing `Project` resource — the layout already groups SFTP/SSH user CRUD here.
- Closes the last two open routes for the SSH/SFTP User tag.

Closes #68.

Source: route list compiled by @pellingh97.

## Test plan

- [ ] `pnpm run test:compile` passes
- [ ] `pnpm run lint` passes
- [ ] In n8n, the new **Get SSH User** / **Get SFTP User** operations appear under the **Project** resource
- [ ] `test/integration/project.sftp-ssh-get.test.ts` passes against a live API (env-gated; auto-skips otherwise)

## Rebase note

This PR is part of milestone [Full mittwald API coverage](https://github.com/mittwald/n8n-nodes/milestone/1) and was opened in parallel with the other tag PRs. If another tag PR from the milestone is merged before this one, this branch will need a rebase against `master` because of additive conflicts on `nodes/Mittwald/resources/implementations/operations.ts` and `README.md`. The conflicts are mechanical (one extra import / one extra section) — GitHub may resolve them automatically via the "Update branch" button; if not, `git pull --rebase origin master` locally is enough.
