### PR TITLE
feat(contributor): add List Contract Partners operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This node provides integration with the [mittwald API v2](https://developer.mitt
 - **List incoming invoices**: Get a list of incoming invoices for an organisation
 - **List outgoing invoices**: Get a list of outgoing invoices for an organisation
 - **List own extensions**: Get a list of extensions owned by an organisation
+- **List contract partners**: Get a list of contract partners associated with a contributor
 
 ### Conversation
 

--- a/nodes/Mittwald/resources/implementations/Contributor/operations/index.ts
+++ b/nodes/Mittwald/resources/implementations/Contributor/operations/index.ts
@@ -1,3 +1,4 @@
+import './listContractPartners';
 import './listIncomingInvoices';
 import './listOutgoingInvoices';
 import './listOwnExtensions';

--- a/nodes/Mittwald/resources/implementations/Contributor/operations/listContractPartners.ts
+++ b/nodes/Mittwald/resources/implementations/Contributor/operations/listContractPartners.ts
@@ -1,0 +1,21 @@
+import organisationProperty from '../../shared/organisationProperty';
+import { contributorResource } from '../resource';
+
+export default contributorResource
+	.addOperation({
+		name: 'List Contract Partners',
+		action: 'List contract partners of a contributor',
+		description: 'Get a list of contract partners associated with a contributor',
+	})
+	.withProperties({
+		organisation: organisationProperty,
+	})
+	.withExecuteFn(async (context) => {
+		const { properties, apiClient } = context;
+		const { organisation } = properties;
+
+		return apiClient.request({
+			path: `/contributors/${organisation}/contract-partners`,
+			method: 'GET',
+		});
+	});

--- a/test/integration/contributor.contractPartners.test.ts
+++ b/test/integration/contributor.contractPartners.test.ts
@@ -3,14 +3,24 @@ import { expect } from 'vitest';
 import { integrationDescribe, testcase } from './testcase';
 
 integrationDescribe('Contributor / List Contract Partners (integration)', () => {
-	testcase('fetches contract partners for a contributor', async ({ runOperation }) => {
-		const result = await runOperation({
+	testcase('fetches contract partners for a contributor', async (context) => {
+		const server = await context.mittwaldApi.project.getServer({
+			serverId: context.env.testServerId,
+		});
+
+		if (server.status !== 200) {
+			throw new Error(`Failed to fetch test server: expected status 200, got ${server.status}`);
+		}
+
+		const organisationId = server.data.customerId;
+
+		const result = await context.runOperation({
 			resource: 'Contributor',
 			operation: 'List Contract Partners',
 			parameters: {
 				organisation: {
 					mode: 'id',
-					value: 'self',
+					value: organisationId,
 				},
 			},
 		});

--- a/test/integration/contributor.contractPartners.test.ts
+++ b/test/integration/contributor.contractPartners.test.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @n8n/community-nodes/no-restricted-imports */
+import { expect } from 'vitest';
+import { integrationDescribe, testcase } from './testcase';
+
+integrationDescribe('Contributor / List Contract Partners (integration)', () => {
+	testcase('fetches contract partners for a contributor', async ({ runOperation }) => {
+		const result = await runOperation({
+			resource: 'Contributor',
+			operation: 'List Contract Partners',
+			parameters: {
+				organisation: {
+					mode: 'id',
+					value: 'self',
+				},
+			},
+		});
+
+		expect(Array.isArray(result.items)).toBe(true);
+	});
+});

--- a/test/integration/contributor.contractPartners.test.ts
+++ b/test/integration/contributor.contractPartners.test.ts
@@ -23,6 +23,7 @@ integrationDescribe('Contributor / List Contract Partners (integration)', () => 
 					value: organisationId,
 				},
 			},
+			allowEmptyItems: true,
 		});
 
 		expect(Array.isArray(result.items)).toBe(true);


### PR DESCRIPTION
## Summary

- Adds the missing **List Contract Partners** operation under the existing `Contributor` resource (`GET /v2/contributors/{contributorId}/contract-partners`).
- Completes the marketplace tag — the only previously open route from the contributors-and-marketplace audit.

Closes #78.

Source: route list compiled by @pellingh97.

## Test plan

- [ ] `pnpm run test:compile` passes
- [ ] `pnpm run lint` passes
- [ ] In n8n, the **List Contract Partners** operation shows up under the **Contributor** resource and returns an array
- [ ] `test/integration/contributor.contractPartners.test.ts` passes against a live API (env-gated; auto-skips otherwise)

## Rebase note

This PR is part of milestone [Full mittwald API coverage](https://github.com/mittwald/n8n-nodes/milestone/1) and was opened in parallel with the other tag PRs. If another tag PR from the milestone is merged before this one, this branch will need a rebase against `master` because of additive conflicts on `nodes/Mittwald/resources/implementations/operations.ts` and `README.md`. The conflicts are mechanical (one extra import / one extra section) — GitHub may resolve them automatically via the "Update branch" button; if not, `git pull --rebase origin master` locally is enough.
