### PR TITLE
feat(conversation): add list, get, list-messages, and send-message operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ This node provides integration with the [mittwald API v2](https://developer.mitt
 ### Conversation
 
 - **Create a ticket**: Create a support ticket in a conversation category
+- **List**: Get all conversations the authenticated user has created or has access to
+- **Get**: Get details of a specific conversation
+- **List messages**: Get all messages of a conversation (parameter: Conversation)
+- **Create a message**: Send a new message in a conversation (parameters: Conversation, Message)
 
 ### Project
 

--- a/nodes/Mittwald/resources/implementations/Conversation/operations/createMessage.ts
+++ b/nodes/Mittwald/resources/implementations/Conversation/operations/createMessage.ts
@@ -1,0 +1,35 @@
+import conversationProperty from '../../shared/conversationProperty';
+import { conversationResource } from '../resource';
+import Z from 'zod';
+
+export default conversationResource
+	.addOperation({
+		name: 'Create Message',
+		action: 'Send a message',
+		description: 'Send a new message in a conversation',
+	})
+	.withProperties({
+		conversation: conversationProperty,
+		message: {
+			displayName: 'Message',
+			type: 'string',
+			default: '',
+			typeOptions: {
+				rows: 4,
+			},
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { conversation, message } = properties;
+
+		return apiClient.request({
+			path: `/conversations/${conversation}/messages`,
+			method: 'POST',
+			requestSchema: Z.object({
+				messageContent: Z.string(),
+			}),
+			body: {
+				messageContent: message,
+			},
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Conversation/operations/get.ts
+++ b/nodes/Mittwald/resources/implementations/Conversation/operations/get.ts
@@ -1,0 +1,20 @@
+import conversationProperty from '../../shared/conversationProperty';
+import { conversationResource } from '../resource';
+
+export default conversationResource
+	.addOperation({
+		name: 'Get',
+		action: 'Get a conversation',
+		description: 'Get details of a specific conversation',
+	})
+	.withProperties({
+		conversation: conversationProperty,
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { conversation } = properties;
+
+		return apiClient.request({
+			path: `/conversations/${conversation}`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Conversation/operations/index.ts
+++ b/nodes/Mittwald/resources/implementations/Conversation/operations/index.ts
@@ -1,1 +1,5 @@
-import './create'
+import './create';
+import './createMessage';
+import './get';
+import './list';
+import './listMessages';

--- a/nodes/Mittwald/resources/implementations/Conversation/operations/list.ts
+++ b/nodes/Mittwald/resources/implementations/Conversation/operations/list.ts
@@ -1,0 +1,15 @@
+import { conversationResource } from '../resource';
+
+export default conversationResource
+	.addOperation({
+		name: 'List',
+		action: 'List conversations',
+		description: 'Get all conversations the authenticated user has created or has access to',
+	})
+	.withProperties({})
+	.withExecuteFn(async ({ apiClient }) => {
+		return apiClient.request({
+			path: `/conversations`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Conversation/operations/listMessages.ts
+++ b/nodes/Mittwald/resources/implementations/Conversation/operations/listMessages.ts
@@ -1,0 +1,20 @@
+import conversationProperty from '../../shared/conversationProperty';
+import { conversationResource } from '../resource';
+
+export default conversationResource
+	.addOperation({
+		name: 'List Messages',
+		action: 'List conversation messages',
+		description: 'Get all messages of a conversation',
+	})
+	.withProperties({
+		conversation: conversationProperty,
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { conversation } = properties;
+
+		return apiClient.request({
+			path: `/conversations/${conversation}/messages`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/shared/conversationProperty.ts
+++ b/nodes/Mittwald/resources/implementations/shared/conversationProperty.ts
@@ -1,0 +1,39 @@
+import { ApiClient } from '../../../api';
+import type { OperationPropertyConfig } from '../../base';
+import Z from 'zod';
+
+export default {
+	displayName: 'Conversation',
+	type: 'resourceLocator',
+	default: '',
+	searchListMethodName: 'searchConversation',
+	async searchListMethod(this, filter, paginationToken) {
+		const apiClient = new ApiClient(this);
+
+		const response = await apiClient.request({
+			path: '/conversations',
+			method: 'GET',
+			qs: {
+				fullTextSearch: filter,
+			},
+			pagination: {
+				token: paginationToken,
+			},
+			responseSchema: Z.array(
+				Z.object({
+					conversationId: Z.string(),
+					shortId: Z.string(),
+					title: Z.string(),
+				}),
+			),
+		});
+
+		return {
+			results: response.body.map((conversation) => ({
+				name: `${conversation.title} (${conversation.shortId})`,
+				value: conversation.conversationId,
+			})),
+			paginationToken: response.nextPaginationToken,
+		};
+	},
+} satisfies OperationPropertyConfig;

--- a/test/integration/conversation.lifecycle.test.ts
+++ b/test/integration/conversation.lifecycle.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable @n8n/community-nodes/no-restricted-imports */
+import { expect } from 'vitest';
+import { fromStep, runId } from './helpers';
+import { integrationDescribe, testcase } from './testcase';
+
+type ConversationCategory = {
+	categoryId: string;
+};
+
+type ConversationApi = {
+	listCategories: () => Promise<{
+		status: number;
+		statusText: string;
+		data: ConversationCategory[];
+	}>;
+	setConversationStatus?: (input: {
+		conversationId: string;
+		data: { status: 'closed' };
+	}) => Promise<unknown>;
+};
+
+integrationDescribe('Conversation / Lifecycle (integration)', () => {
+	testcase(
+		'creates a conversation, sends a message, lists messages, and gets the conversation',
+		async (context) => {
+			const conversationApi = context.mittwaldApi.conversation as unknown as ConversationApi;
+			const categoryId = await getFirstConversationCategoryId(conversationApi);
+			const title = `it-${runId('conversation-flow')}`;
+			const message = 'integration test ping';
+
+			const teardownState: { createdConversationId?: string } = {};
+			context.teardown(async () => {
+				if (!teardownState.createdConversationId || !conversationApi.setConversationStatus) {
+					return;
+				}
+
+				await conversationApi.setConversationStatus({
+					conversationId: teardownState.createdConversationId,
+					data: { status: 'closed' },
+				});
+			});
+
+			const result = await context
+				.scenario('Conversation lifecycle')
+				.step({
+					name: 'Create Conversation',
+					resource: 'Support',
+					operation: 'Create',
+					parameters: {
+						conversationCategory: {
+							mode: 'id',
+							value: categoryId,
+						},
+						title,
+						message: 'integration test start',
+					},
+				})
+				.step({
+					name: 'Create Message',
+					resource: 'Support',
+					operation: 'Create Message',
+					parameters: {
+						conversation: fromStep('Create Conversation', 'conversationId'),
+						message,
+					},
+				})
+				.step({
+					name: 'List Messages',
+					resource: 'Support',
+					operation: 'List Messages',
+					parameters: {
+						conversation: fromStep('Create Conversation', 'conversationId'),
+					},
+				})
+				.step({
+					name: 'Get Conversation',
+					resource: 'Support',
+					operation: 'Get',
+					parameters: {
+						conversation: fromStep('Create Conversation', 'conversationId'),
+					},
+				})
+				.run();
+
+			teardownState.createdConversationId = result
+				.step('Create Conversation')
+				.requireString('conversationId');
+
+			expect(result.step('Create Message').requireString('conversationId')).toBe(
+				teardownState.createdConversationId,
+			);
+			expect(result.step('List Messages').stringValues('messageContent')).toContain(message);
+			expect(result.step('Get Conversation').requireString('conversationId')).toBe(
+				teardownState.createdConversationId,
+			);
+			expect(result.step('Get Conversation').requireString('title')).toBe(title);
+		},
+		10_000,
+	);
+});
+
+async function getFirstConversationCategoryId(
+	conversationApi: ConversationApi,
+): Promise<string> {
+	const response = await conversationApi.listCategories();
+
+	if (response.status !== 200) {
+		throw new Error(`Failed to list conversation categories: ${response.statusText}`);
+	}
+
+	const firstCategory = response.data[0];
+	if (!firstCategory) {
+		throw new Error('No conversation categories are available for integration testing');
+	}
+
+	return firstCategory.categoryId;
+}


### PR DESCRIPTION
## Summary

- Adds four missing operations to the existing **Conversation** resource:
  - **List** — `GET /v2/conversations`
  - **Get** — `GET /v2/conversations/{conversationId}`
  - **List Messages** — `GET /v2/conversations/{conversationId}/messages`
  - **Create Message** — `POST /v2/conversations/{conversationId}/messages`
- Introduces a `conversationProperty` resource locator so users can pick a conversation from a searchable dropdown.

Closes #74.

Source: route list compiled by @pellingh97.

## Test plan

- [ ] `pnpm run test:compile` passes
- [ ] `pnpm run lint` passes
- [ ] In n8n, the four new operations appear under the **Conversation** resource
- [ ] `test/integration/conversation.lifecycle.test.ts` (create → send → list → get → cleanup) passes against a live API (env-gated; auto-skips otherwise)

## Rebase note

This PR is part of milestone [Full mittwald API coverage](https://github.com/mittwald/n8n-nodes/milestone/1) and was opened in parallel with the other tag PRs. If another tag PR from the milestone is merged before this one, this branch will need a rebase against `master` because of additive conflicts on `nodes/Mittwald/resources/implementations/operations.ts` and `README.md`. The conflicts are mechanical (one extra import / one extra section) — GitHub may resolve them automatically via the "Update branch" button; if not, `git pull --rebase origin master` locally is enough.
