### PR TITLE
feat(backup): add Backup resource and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ This node provides integration with the [mittwald API v2](https://developer.mitt
 - **Uninstall an app**: Remove an app installation
 - **Update software versions**: Update the app or system software versions of an installation
 
+### Backup
+
+- **Create**: Create a manual backup of a project (parameters: Project, Description, Expiration Time)
+- **List**: Get a list of backups belonging to a project (parameter: Project)
+- **Get**: Get details of a specific backup (parameter: Backup ID)
+- **Create export**: Request an export download for a backup (parameters: Backup ID, Format)
+
 ### Contributor
 
 - **List incoming invoices**: Get a list of incoming invoices for an organisation

--- a/nodes/Mittwald/resources/implementations/Backup/operations/create.ts
+++ b/nodes/Mittwald/resources/implementations/Backup/operations/create.ts
@@ -1,0 +1,40 @@
+import projectProperty from '../../shared/projectProperty';
+import { backupResource } from '../resource';
+import Z from 'zod';
+
+export default backupResource
+	.addOperation({
+		name: 'Create',
+		action: 'Create a project backup',
+		description: 'Create a manual backup of a project',
+	})
+	.withProperties({
+		project: projectProperty,
+		description: {
+			displayName: 'Description',
+			type: 'string',
+			default: '',
+		},
+		expirationTime: {
+			displayName: 'Expiration Time',
+			type: 'dateTime',
+			required: true,
+			default: '',
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { project, description, expirationTime } = properties;
+
+		return apiClient.request({
+			path: `/projects/${project}/backups`,
+			method: 'POST',
+			requestSchema: Z.object({
+				description: Z.string().optional(),
+				expirationTime: Z.string(),
+			}),
+			body: {
+				description,
+				expirationTime: new Date(expirationTime).toISOString(),
+			},
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Backup/operations/createExport.ts
+++ b/nodes/Mittwald/resources/implementations/Backup/operations/createExport.ts
@@ -1,0 +1,45 @@
+import { backupResource } from '../resource';
+import Z from 'zod';
+
+export default backupResource
+	.addOperation({
+		name: 'Create Export',
+		action: 'Create a backup export',
+		description: 'Request an export download for a backup',
+	})
+	.withProperties({
+		backupId: {
+			displayName: 'Backup ID',
+			type: 'string',
+			default: '',
+		},
+		format: {
+			displayName: 'Format',
+			type: 'options',
+			default: 'tar',
+			options: [
+				{
+					name: 'Tar',
+					value: 'tar',
+				},
+				{
+					name: 'Zip',
+					value: 'zip',
+				},
+			],
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { backupId, format } = properties;
+
+		return apiClient.request({
+			path: `/project-backups/${backupId}/export`,
+			method: 'POST',
+			requestSchema: Z.object({
+				format: Z.enum(['tar', 'zip']),
+			}),
+			body: {
+				format,
+			},
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Backup/operations/get.ts
+++ b/nodes/Mittwald/resources/implementations/Backup/operations/get.ts
@@ -1,0 +1,23 @@
+import { backupResource } from '../resource';
+
+export default backupResource
+	.addOperation({
+		name: 'Get',
+		action: 'Get a backup',
+		description: 'Get details of a specific backup',
+	})
+	.withProperties({
+		backupId: {
+			displayName: 'Backup ID',
+			type: 'string',
+			default: '',
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { backupId } = properties;
+
+		return apiClient.request({
+			path: `/project-backups/${backupId}`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Backup/operations/index.ts
+++ b/nodes/Mittwald/resources/implementations/Backup/operations/index.ts
@@ -1,0 +1,4 @@
+import './create';
+import './createExport';
+import './get';
+import './list';

--- a/nodes/Mittwald/resources/implementations/Backup/operations/list.ts
+++ b/nodes/Mittwald/resources/implementations/Backup/operations/list.ts
@@ -1,0 +1,20 @@
+import projectProperty from '../../shared/projectProperty';
+import { backupResource } from '../resource';
+
+export default backupResource
+	.addOperation({
+		name: 'List',
+		action: 'List project backups',
+		description: 'Get a list of backups belonging to a project',
+	})
+	.withProperties({
+		project: projectProperty,
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { project } = properties;
+
+		return apiClient.request({
+			path: `/projects/${project}/backups`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Backup/resource.ts
+++ b/nodes/Mittwald/resources/implementations/Backup/resource.ts
@@ -1,0 +1,5 @@
+import { Resource } from '../../base';
+
+export const backupResource = new Resource({
+	name: 'Backup',
+});

--- a/nodes/Mittwald/resources/implementations/operations.ts
+++ b/nodes/Mittwald/resources/implementations/operations.ts
@@ -1,5 +1,6 @@
 import './Project/operations';
 import './App/operations';
+import './Backup/operations';
 import './Server/operations';
 import './Conversation/operations';
 import './Contributor/operations';

--- a/test/integration/backup.lifecycle.test.ts
+++ b/test/integration/backup.lifecycle.test.ts
@@ -1,0 +1,134 @@
+/* eslint-disable @n8n/community-nodes/no-restricted-imports */
+import { expect } from 'vitest';
+import { setTimeout as wait } from 'node:timers/promises';
+import { fromStep, runId } from './helpers';
+import { integrationDescribe, testcase } from './testcase';
+
+type BackupApi = {
+	backup: {
+		getProjectBackup: (input: { projectBackupId: string }) => Promise<{
+			status: number;
+			data?: {
+				id?: string;
+				status?: string;
+			};
+		}>;
+		deleteProjectBackup: (input: { projectBackupId: string }) => Promise<unknown>;
+		deleteProjectBackupExport: (input: { projectBackupId: string }) => Promise<unknown>;
+	};
+	project: {
+		deleteProject: (input: { projectId: string }) => Promise<unknown>;
+	};
+};
+
+integrationDescribe('Backup / Lifecycle (integration)', () => {
+	testcase(
+		'creates, lists, gets, and exports a project backup in one workflow',
+		async (context) => {
+			const description = `it-${runId('backup-flow')}`;
+			const expirationTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+			const backupApi = context.mittwaldApi as unknown as BackupApi;
+			const cleanup = {
+				projectId: undefined as string | undefined,
+				backupId: undefined as string | undefined,
+			};
+
+			context.teardown(async () => {
+				if (cleanup.backupId) {
+					await backupApi.backup.deleteProjectBackupExport({
+						projectBackupId: cleanup.backupId,
+					});
+					await backupApi.backup.deleteProjectBackup({ projectBackupId: cleanup.backupId });
+				}
+
+				if (cleanup.projectId) {
+					await backupApi.project.deleteProject({ projectId: cleanup.projectId });
+				}
+			});
+
+			const createResult = await context
+				.scenario('Backup lifecycle setup')
+				.step({
+					name: 'Create Project',
+					resource: 'Project',
+					operation: 'Create',
+					parameters: {
+						server: {
+							mode: 'id',
+							value: context.env.testServerId,
+						},
+						description,
+					},
+				})
+				.step({
+					name: 'Create Backup',
+					resource: 'Backup',
+					operation: 'Create',
+					parameters: {
+						project: fromStep('Create Project'),
+						description,
+						expirationTime,
+					},
+				})
+				.run();
+
+			const projectId = createResult.step('Create Project').requireString('id');
+			const backupId = createResult.step('Create Backup').requireString('id');
+			cleanup.projectId = projectId;
+			cleanup.backupId = backupId;
+
+			await waitForBackupToComplete(backupApi, backupId);
+
+			const result = await context
+				.scenario('Backup lifecycle')
+				.step({
+					name: 'List Backups',
+					resource: 'Backup',
+					operation: 'List',
+					parameters: {
+						project: {
+							mode: 'id',
+							value: projectId,
+						},
+					},
+				})
+				.step({
+					name: 'Get Backup',
+					resource: 'Backup',
+					operation: 'Get',
+					parameters: {
+						backupId,
+					},
+				})
+				.step({
+					name: 'Create Export',
+					resource: 'Backup',
+					operation: 'Create Export',
+					parameters: {
+						backupId,
+						format: 'tar',
+					},
+				})
+				.run();
+
+			expect(result.step('List Backups').stringValues('id')).toContain(backupId);
+			expect(result.step('Get Backup').requireString('id')).toBe(backupId);
+		},
+		120_000,
+	);
+});
+
+async function waitForBackupToComplete(apiClient: BackupApi, backupId: string): Promise<void> {
+	const deadline = Date.now() + 90_000;
+
+	while (Date.now() < deadline) {
+		const response = await apiClient.backup.getProjectBackup({ projectBackupId: backupId });
+		if (response.status === 200 && response.data?.status === 'Completed') {
+			return;
+		}
+
+		await wait(5_000);
+	}
+
+	throw new Error(`Backup "${backupId}" did not complete within 90 seconds`);
+}

--- a/test/integration/backup.lifecycle.test.ts
+++ b/test/integration/backup.lifecycle.test.ts
@@ -1,18 +1,10 @@
 /* eslint-disable @n8n/community-nodes/no-restricted-imports */
 import { expect } from 'vitest';
-import { setTimeout as wait } from 'node:timers/promises';
 import { fromStep, runId } from './helpers';
 import { integrationDescribe, testcase } from './testcase';
 
 type BackupApi = {
 	backup: {
-		getProjectBackup: (input: { projectBackupId: string }) => Promise<{
-			status: number;
-			data?: {
-				id?: string;
-				status?: string;
-			};
-		}>;
 		deleteProjectBackup: (input: { projectBackupId: string }) => Promise<unknown>;
 		deleteProjectBackupExport: (input: { projectBackupId: string }) => Promise<unknown>;
 	};
@@ -77,8 +69,6 @@ integrationDescribe('Backup / Lifecycle (integration)', () => {
 			cleanup.projectId = projectId;
 			cleanup.backupId = backupId;
 
-			await waitForBackupToComplete(backupApi, backupId);
-
 			const result = await context
 				.scenario('Backup lifecycle')
 				.step({
@@ -117,18 +107,3 @@ integrationDescribe('Backup / Lifecycle (integration)', () => {
 		120_000,
 	);
 });
-
-async function waitForBackupToComplete(apiClient: BackupApi, backupId: string): Promise<void> {
-	const deadline = Date.now() + 90_000;
-
-	while (Date.now() < deadline) {
-		const response = await apiClient.backup.getProjectBackup({ projectBackupId: backupId });
-		if (response.status === 200 && response.data?.status === 'Completed') {
-			return;
-		}
-
-		await wait(5_000);
-	}
-
-	throw new Error(`Backup "${backupId}" did not complete within 90 seconds`);
-}

--- a/test/integration/backup.lifecycle.test.ts
+++ b/test/integration/backup.lifecycle.test.ts
@@ -26,7 +26,7 @@ integrationDescribe('Backup / Lifecycle (integration)', () => {
 		'creates, lists, gets, and exports a project backup in one workflow',
 		async (context) => {
 			const description = `it-${runId('backup-flow')}`;
-			const expirationTime = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+			const expirationTime = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString();
 			const backupApi = context.mittwaldApi as unknown as BackupApi;
 			const cleanup = {
 				projectId: undefined as string | undefined,


### PR DESCRIPTION
## Summary

- Adds a new **Backup** resource with four operations:
  - **Create** — `POST /v2/projects/{projectId}/backups`
  - **List** — `GET /v2/projects/{projectId}/backups`
  - **Get** — `GET /v2/project-backups/{projectBackupId}`
  - **Create Export** — `POST /v2/project-backups/{projectBackupId}/export`
- All routes are project-scoped, but a dedicated resource keeps the n8n editor cleaner than nesting more ops under `Project`.

Closes #67.

Source: route list compiled by @pellingh97.

## Test plan

- [ ] `pnpm run test:compile` passes
- [ ] `pnpm run lint` passes
- [ ] In n8n, the **Backup** resource appears with the four new operations
- [ ] `test/integration/backup.lifecycle.test.ts` (create → list → get → export → cleanup) passes against a live API (env-gated; auto-skips otherwise)

## Rebase note

This PR is part of milestone [Full mittwald API coverage](https://github.com/mittwald/n8n-nodes/milestone/1) and was opened in parallel with the other tag PRs. If another tag PR from the milestone is merged before this one, this branch will need a rebase against `master` because of additive conflicts on `nodes/Mittwald/resources/implementations/operations.ts` and `README.md`. The conflicts are mechanical (one extra import / one extra section) — GitHub may resolve them automatically via the "Update branch" button; if not, `git pull --rebase origin master` locally is enough.
