### PR TITLE
feat(contract): add Contract resource and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ This node provides integration with the [mittwald API v2](https://developer.mitt
 - **List outgoing invoices**: Get a list of outgoing invoices for an organisation
 - **List own extensions**: Get a list of extensions owned by an organisation
 
+### Contract
+
+- **Terminate a contract**: Schedule the termination of a contract (parameters: Contract ID, optional Target Date, optional Reason)
+- **Terminate a contract item**: Schedule the termination of a contract item (parameters: Contract ID, Contract Item ID, optional Target Date, optional Reason)
+- **Get an invoice**: Get details of an invoice (parameter: Invoice ID)
+- **List invoices**: Get a list of invoices for a customer (parameter: Customer ID)
+
 ### Conversation
 
 - **Create a ticket**: Create a support ticket in a conversation category

--- a/nodes/Mittwald/resources/implementations/Contract/operations/getInvoice.ts
+++ b/nodes/Mittwald/resources/implementations/Contract/operations/getInvoice.ts
@@ -1,0 +1,19 @@
+import { contractResource } from '../resource';
+
+export default contractResource
+	.addOperation({
+		name: 'Get Invoice',
+		action: 'Get an invoice',
+		description: 'Get details of an invoice',
+	})
+	.withProperties({
+		invoiceId: { displayName: 'Invoice ID', type: 'string', default: '' },
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { invoiceId } = properties;
+
+		return apiClient.request({
+			path: `/invoices/${invoiceId}`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Contract/operations/index.ts
+++ b/nodes/Mittwald/resources/implementations/Contract/operations/index.ts
@@ -1,0 +1,4 @@
+import './terminate';
+import './terminateItem';
+import './getInvoice';
+import './listInvoices';

--- a/nodes/Mittwald/resources/implementations/Contract/operations/listInvoices.ts
+++ b/nodes/Mittwald/resources/implementations/Contract/operations/listInvoices.ts
@@ -1,0 +1,19 @@
+import { contractResource } from '../resource';
+
+export default contractResource
+	.addOperation({
+		name: 'List Invoices',
+		action: 'List invoices',
+		description: 'Get a list of invoices for a customer',
+	})
+	.withProperties({
+		customerId: { displayName: 'Customer ID', type: 'string', default: '' },
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { customerId } = properties;
+
+		return apiClient.request({
+			path: `/customers/${customerId}/invoices`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Contract/operations/listInvoices.ts
+++ b/nodes/Mittwald/resources/implementations/Contract/operations/listInvoices.ts
@@ -1,19 +1,20 @@
+import organisationProperty from '../../shared/organisationProperty';
 import { contractResource } from '../resource';
 
 export default contractResource
 	.addOperation({
 		name: 'List Invoices',
 		action: 'List invoices',
-		description: 'Get a list of invoices for a customer',
+		description: 'Get a list of invoices for an organisation',
 	})
 	.withProperties({
-		customerId: { displayName: 'Customer ID', type: 'string', default: '' },
+		organisation: organisationProperty,
 	})
 	.withExecuteFn(async ({ properties, apiClient }) => {
-		const { customerId } = properties;
+		const { organisation } = properties;
 
 		return apiClient.request({
-			path: `/customers/${customerId}/invoices`,
+			path: `/customers/${organisation}/invoices`,
 			method: 'GET',
 		});
 	});

--- a/nodes/Mittwald/resources/implementations/Contract/operations/terminate.ts
+++ b/nodes/Mittwald/resources/implementations/Contract/operations/terminate.ts
@@ -1,0 +1,30 @@
+import { contractResource } from '../resource';
+import Z from 'zod';
+
+export default contractResource
+	.addOperation({
+		name: 'Terminate',
+		action: 'Schedule the termination of a contract',
+		description: 'Schedule the termination of a contract',
+	})
+	.withProperties({
+		contractId: { displayName: 'Contract ID', type: 'string', default: '' },
+		targetDate: { displayName: 'Target Date', type: 'dateTime', default: '' },
+		reason: { displayName: 'Reason', type: 'string', default: '' },
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { contractId, targetDate, reason } = properties;
+
+		return apiClient.request({
+			path: `/contracts/${contractId}/termination`,
+			method: 'POST',
+			requestSchema: Z.object({
+				terminationTargetDate: Z.string().optional(),
+				reason: Z.string().optional(),
+			}),
+			body: {
+				terminationTargetDate: targetDate ? new Date(targetDate).toISOString() : undefined,
+				reason: reason || undefined,
+			},
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Contract/operations/terminateItem.ts
+++ b/nodes/Mittwald/resources/implementations/Contract/operations/terminateItem.ts
@@ -1,0 +1,31 @@
+import { contractResource } from '../resource';
+import Z from 'zod';
+
+export default contractResource
+	.addOperation({
+		name: 'Terminate Item',
+		action: 'Schedule the termination of a contract item',
+		description: 'Schedule the termination of a contract item',
+	})
+	.withProperties({
+		contractId: { displayName: 'Contract ID', type: 'string', default: '' },
+		contractItemId: { displayName: 'Contract Item ID', type: 'string', default: '' },
+		targetDate: { displayName: 'Target Date', type: 'dateTime', default: '' },
+		reason: { displayName: 'Reason', type: 'string', default: '' },
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const { contractId, contractItemId, targetDate, reason } = properties;
+
+		return apiClient.request({
+			path: `/contracts/${contractId}/items/${contractItemId}/termination`,
+			method: 'POST',
+			requestSchema: Z.object({
+				terminationTargetDate: Z.string().optional(),
+				reason: Z.string().optional(),
+			}),
+			body: {
+				terminationTargetDate: targetDate ? new Date(targetDate).toISOString() : undefined,
+				reason: reason || undefined,
+			},
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Contract/resource.ts
+++ b/nodes/Mittwald/resources/implementations/Contract/resource.ts
@@ -1,0 +1,5 @@
+import { Resource } from '../../base';
+
+export const contractResource = new Resource({
+	name: 'Contract',
+});

--- a/nodes/Mittwald/resources/implementations/operations.ts
+++ b/nodes/Mittwald/resources/implementations/operations.ts
@@ -5,3 +5,4 @@ import './Conversation/operations';
 import './Contributor/operations';
 import './Domain/operations';
 import './Database/operations';
+import './Contract/operations';

--- a/test/integration/contract.read.test.ts
+++ b/test/integration/contract.read.test.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @n8n/community-nodes/no-restricted-imports */
+import { expect } from 'vitest';
+import { integrationDescribe, readOptionalString, testcase } from './testcase';
+
+declare const process: { env: Record<string, string | undefined> };
+
+integrationDescribe('Contract / Invoice read operations (integration)', () => {
+	testcase('lists customer invoices and fetches the first invoice when available', async ({
+		runOperation,
+	}) => {
+		const testCustomerId = process.env.IT_CUSTOMER_ID;
+		if (!testCustomerId) {
+			return;
+		}
+
+		const listResult = await runOperation({
+			resource: 'Contract',
+			operation: 'List Invoices',
+			parameters: {
+				customerId: testCustomerId,
+			},
+			allowEmptyItems: true,
+		});
+
+		expect(Array.isArray(listResult.items)).toBe(true);
+
+		const firstInvoiceId = listResult.items
+			.map((item) => readOptionalString(item.json, 'id'))
+			.find((invoiceId): invoiceId is string => Boolean(invoiceId));
+		if (!firstInvoiceId) {
+			return;
+		}
+
+		const getResult = await runOperation({
+			resource: 'Contract',
+			operation: 'Get Invoice',
+			parameters: {
+				invoiceId: firstInvoiceId,
+			},
+		});
+
+		expect(getResult.firstItem.json.id).toBe(firstInvoiceId);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a new **Contract** resource with four operations:
  - **Terminate** — `POST /v2/contracts/{contractId}/termination`
  - **Terminate Item** — `POST /v2/contracts/{contractId}/items/{contractItemId}/termination`
  - **Get Invoice** — `GET /v2/invoices/{invoiceId}`
  - **List Invoices** — `GET /v2/customers/{customerId}/invoices`
- The integration test is read-only on purpose (list + get-by-id) — the two `Terminate*` ops mutate real billing state and should not be exercised against a live customer in CI.

Closes #71.

Source: route list compiled by @pellingh97.

## Test plan

- [ ] `pnpm run test:compile` passes
- [ ] `pnpm run lint` passes
- [ ] In n8n, the **Contract** resource appears with the four new operations
- [ ] `test/integration/contract.read.test.ts` (list invoices + optional get-first-invoice) passes against a live API (env-gated; auto-skips otherwise)

## Coverage caveats

These operations are not exercised by the integration tests on purpose:

- **Terminate** and **Terminate Item** — both schedule a termination on a real contract / contract item and mutate billing state. Compile + lint cover the request schema's structural correctness; runtime testing should happen on a sandboxed billing environment, not in CI.

If this becomes important later, follow the env-gated pattern used by `test/integration/contract.read.test.ts` itself (`IT_CUSTOMER_ID`) — gate the destructive call on a dedicated `IT_TERMINATABLE_CONTRACT_ID` env var so unset envs skip silently.

## Rebase note

This PR is part of milestone [Full mittwald API coverage](https://github.com/mittwald/n8n-nodes/milestone/1) and was opened in parallel with the other tag PRs. If another tag PR from the milestone is merged before this one, this branch will need a rebase against `master` because of additive conflicts on `nodes/Mittwald/resources/implementations/operations.ts` and `README.md`. The conflicts are mechanical (one extra import / one extra section) — GitHub may resolve them automatically via the "Update branch" button; if not, `git pull --rebase origin master` locally is enough.
