### PR TITLE
feat(database): add MySQL CRUD and version-listing operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This node provides integration with the [mittwald API v2](https://developer.mitt
 - **Create MySQL database**: Create a new MySQL database with an initial user in a project (parameters: Project, Name, Version, Character Set, Collation, User Password, User Access Level, optional User External Access, optional User Description)
 - **Get a MySQL database**: Get details of a specific MySQL database (parameter: MySQL Database ID)
 - **Delete MySQL database**: Delete an existing MySQL database (parameter: MySQL Database ID)
-- **Copy MySQL database**: Copy a MySQL database with its own initial user (parameters: source MySQL Database ID, Name, User Password, User Access Level, optional User External Access, optional User Description)
+- **Copy MySQL database**: Copy a MySQL database with its own initial user (parameters: source MySQL Database ID, Name, User Password, optional User External Access; the copied user is created with full access)
 - **List MySQL versions**: Get a list of available MySQL versions
 - **List Redis versions**: Get a list of available Redis versions
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ This node provides integration with the [mittwald API v2](https://developer.mitt
 - **Create Redis database**: Create a new Redis database in a project
 - **Delete Redis database**: Delete an existing Redis database
 - **Get a Redis database**: Get details of a specific Redis database
+- **List all MySQL databases**: Get a list of all MySQL databases in a project (parameter: Project)
+- **Create MySQL database**: Create a new MySQL database with an initial user in a project (parameters: Project, Name, Version, Character Set, Collation, User Password, User Access Level, optional User External Access, optional User Description)
+- **Get a MySQL database**: Get details of a specific MySQL database (parameter: MySQL Database ID)
+- **Delete MySQL database**: Delete an existing MySQL database (parameter: MySQL Database ID)
+- **Copy MySQL database**: Copy a MySQL database with its own initial user (parameters: source MySQL Database ID, Name, User Password, User Access Level, optional User External Access, optional User Description)
+- **List MySQL versions**: Get a list of available MySQL versions
+- **List Redis versions**: Get a list of available Redis versions
 
 ### Server
 

--- a/nodes/Mittwald/resources/implementations/Database/operations/index.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/index.ts
@@ -1,4 +1,11 @@
+import './mysqlCopy';
+import './mysqlCreate';
+import './mysqlDelete';
+import './mysqlGet';
+import './mysqlList';
+import './mysqlVersions';
 import './redisCreate';
 import './redisDelete';
 import './redisGet';
 import './redisList';
+import './redisVersions';

--- a/nodes/Mittwald/resources/implementations/Database/operations/mysqlCopy.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/mysqlCopy.ts
@@ -1,0 +1,112 @@
+import { databaseResource } from '../resource';
+import Z from 'zod';
+
+export default databaseResource
+	.addOperation({
+		name: 'Copy MySQL Database',
+		action: 'Copy a MySQL database',
+		description: 'Copy a MySQL database into a new database with its own user',
+	})
+	.withProperties({
+		mysqlDatabaseId: {
+			displayName: 'Source MySQL Database ID',
+			type: 'string',
+			required: true,
+			default: '',
+			description: 'ID of the MySQL database to copy',
+		},
+		description: {
+			displayName: 'Name',
+			type: 'string',
+			required: true,
+			default: '',
+			description: 'Description for the new MySQL database',
+		},
+		userPassword: {
+			displayName: 'User Password',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			required: true,
+			default: '',
+			description: 'Password for the user of the copied database',
+		},
+		userAccessLevel: {
+			displayName: 'User Access Level',
+			type: 'options',
+			default: 'full',
+			options: [
+				{
+					name: 'Full',
+					value: 'full',
+				},
+				{
+					name: 'Read-Only',
+					value: 'readonly',
+				},
+			],
+		},
+		userExternalAccess: {
+			displayName: 'User External Access',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to allow external access for the user of the copied database',
+		},
+		userDescription: {
+			displayName: 'User Description',
+			type: 'string',
+			default: '',
+			description: 'Optional description for the user of the copied database',
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const {
+			mysqlDatabaseId,
+			description,
+			userPassword,
+			userAccessLevel,
+			userExternalAccess,
+			userDescription,
+		} = properties;
+
+		const copy = await apiClient.request({
+			path: `/mysql-databases/${mysqlDatabaseId}/actions/copy`,
+			method: 'POST',
+			requestSchema: Z.object({
+				database: Z.object({
+					description: Z.string().min(1),
+				}),
+				user: Z.object({
+					password: Z.string().min(1),
+					accessLevel: Z.enum(['full', 'readonly']),
+					externalAccess: Z.boolean(),
+					description: Z.string().optional(),
+				}),
+			}),
+			responseSchema: Z.object({
+				id: Z.string().uuid(),
+			}),
+			body: {
+				database: {
+					description,
+				},
+				user: {
+					password: userPassword,
+					accessLevel: userAccessLevel,
+					externalAccess: userExternalAccess,
+					description: userDescription || undefined,
+				},
+			},
+		});
+
+		return apiClient.request({
+			path: `/mysql-databases/${copy.id}`,
+			method: 'GET',
+			polling: {
+				waitUntil: {
+					untilSuccess: true,
+				},
+			},
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Database/operations/mysqlCopy.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/mysqlCopy.ts
@@ -32,70 +32,37 @@ export default databaseResource
 			default: '',
 			description: 'Password for the user of the copied database',
 		},
-		userAccessLevel: {
-			displayName: 'User Access Level',
-			type: 'options',
-			default: 'full',
-			options: [
-				{
-					name: 'Full',
-					value: 'full',
-				},
-				{
-					name: 'Read-Only',
-					value: 'readonly',
-				},
-			],
-		},
 		userExternalAccess: {
 			displayName: 'User External Access',
 			type: 'boolean',
 			default: false,
 			description: 'Whether to allow external access for the user of the copied database',
 		},
-		userDescription: {
-			displayName: 'User Description',
-			type: 'string',
-			default: '',
-			description: 'Optional description for the user of the copied database',
-		},
 	})
 	.withExecuteFn(async ({ properties, apiClient }) => {
-		const {
-			mysqlDatabaseId,
-			description,
-			userPassword,
-			userAccessLevel,
-			userExternalAccess,
-			userDescription,
-		} = properties;
+		const { mysqlDatabaseId, description, userPassword, userExternalAccess } = properties;
 
 		const copy = await apiClient.request({
 			path: `/mysql-databases/${mysqlDatabaseId}/actions/copy`,
 			method: 'POST',
 			requestSchema: Z.object({
-				database: Z.object({
-					description: Z.string().min(1),
-				}),
+				description: Z.string().min(1),
 				user: Z.object({
 					password: Z.string().min(1),
-					accessLevel: Z.enum(['full', 'readonly']),
+					accessLevel: Z.literal('full'),
 					externalAccess: Z.boolean(),
-					description: Z.string().optional(),
 				}),
 			}),
 			responseSchema: Z.object({
-				id: Z.string().uuid(),
+				id: Z.string(),
+				userId: Z.string(),
 			}),
 			body: {
-				database: {
-					description,
-				},
+				description,
 				user: {
 					password: userPassword,
-					accessLevel: userAccessLevel,
+					accessLevel: 'full',
 					externalAccess: userExternalAccess,
-					description: userDescription || undefined,
 				},
 			},
 		});

--- a/nodes/Mittwald/resources/implementations/Database/operations/mysqlCreate.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/mysqlCreate.ts
@@ -1,0 +1,134 @@
+import { databaseResource } from '../resource';
+import projectProperty from '../../shared/projectProperty';
+import mysqlVersionProperty from '../../shared/mysqlVersionProperty';
+import Z from 'zod';
+
+export default databaseResource
+	.addOperation({
+		name: 'Create MySQL Database',
+		action: 'Create a MySQL database',
+		description: 'Create a new MySQL database with an initial user in a project',
+	})
+	.withProperties({
+		project: projectProperty,
+		description: {
+			displayName: 'Name',
+			type: 'string',
+			required: true,
+			default: '',
+		},
+		version: mysqlVersionProperty,
+		characterSet: {
+			displayName: 'Character Set',
+			type: 'string',
+			default: 'utf8mb4',
+			description: 'Character set used for the database',
+		},
+		collation: {
+			displayName: 'Collation',
+			type: 'string',
+			default: 'utf8mb4_unicode_ci',
+			description: 'Collation used for the database',
+		},
+		userPassword: {
+			displayName: 'User Password',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			required: true,
+			default: '',
+			description: 'Password for the initial MySQL user',
+		},
+		userAccessLevel: {
+			displayName: 'User Access Level',
+			type: 'options',
+			default: 'full',
+			options: [
+				{
+					name: 'Full',
+					value: 'full',
+				},
+				{
+					name: 'Read-Only',
+					value: 'readonly',
+				},
+			],
+			description: 'Access level granted to the initial user',
+		},
+		userExternalAccess: {
+			displayName: 'User External Access',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to allow external access for the initial user',
+		},
+		userDescription: {
+			displayName: 'User Description',
+			type: 'string',
+			default: '',
+			description: 'Optional description for the initial user',
+		},
+	})
+	.withExecuteFn(async ({ properties, apiClient }) => {
+		const {
+			project,
+			description,
+			version,
+			characterSet,
+			collation,
+			userPassword,
+			userAccessLevel,
+			userExternalAccess,
+			userDescription,
+		} = properties;
+
+		const mysqlDatabase = await apiClient.request({
+			path: `/projects/${project}/mysql-databases`,
+			method: 'POST',
+			requestSchema: Z.object({
+				database: Z.object({
+					description: Z.string().min(1),
+					version: Z.string(),
+					characterSettings: Z.object({
+						characterSet: Z.string(),
+						collation: Z.string(),
+					}),
+				}),
+				user: Z.object({
+					password: Z.string().min(1),
+					accessLevel: Z.enum(['full', 'readonly']),
+					externalAccess: Z.boolean(),
+					description: Z.string().optional(),
+				}),
+			}),
+			responseSchema: Z.object({
+				id: Z.string().uuid(),
+			}),
+			body: {
+				database: {
+					description,
+					version,
+					characterSettings: {
+						characterSet,
+						collation,
+					},
+				},
+				user: {
+					password: userPassword,
+					accessLevel: userAccessLevel,
+					externalAccess: userExternalAccess,
+					description: userDescription || undefined,
+				},
+			},
+		});
+
+		return apiClient.request({
+			path: `/mysql-databases/${mysqlDatabase.id}`,
+			method: 'GET',
+			polling: {
+				waitUntil: {
+					untilSuccess: true,
+				},
+			},
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Database/operations/mysqlDelete.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/mysqlDelete.ts
@@ -1,0 +1,24 @@
+import { databaseResource } from '../resource';
+
+export default databaseResource
+	.addOperation({
+		name: 'Delete MySQL Database',
+		action: 'Delete a MySQL database',
+		description: 'Delete an existing MySQL database',
+	})
+	.withProperties({
+		mysqlDatabaseId: {
+			displayName: 'MySQL Database ID',
+			type: 'string',
+			default: '',
+		},
+	})
+	.withExecuteFn(async (context) => {
+		const { properties, apiClient } = context;
+		const { mysqlDatabaseId } = properties;
+
+		return apiClient.request({
+			path: `/mysql-databases/${mysqlDatabaseId}`,
+			method: 'DELETE',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Database/operations/mysqlGet.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/mysqlGet.ts
@@ -1,0 +1,24 @@
+import { databaseResource } from '../resource';
+
+export default databaseResource
+	.addOperation({
+		name: 'Get MySQL Database',
+		action: 'Get a MySQL database',
+		description: 'Get details of a specific MySQL database',
+	})
+	.withProperties({
+		mysqlDatabaseId: {
+			displayName: 'MySQL Database ID',
+			type: 'string',
+			default: '',
+		},
+	})
+	.withExecuteFn(async (context) => {
+		const { properties, apiClient } = context;
+		const { mysqlDatabaseId } = properties;
+
+		return apiClient.request({
+			path: `/mysql-databases/${mysqlDatabaseId}`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Database/operations/mysqlList.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/mysqlList.ts
@@ -1,0 +1,21 @@
+import projectProperty from '../../shared/projectProperty';
+import { databaseResource } from '../resource';
+
+export default databaseResource
+	.addOperation({
+		name: 'List MySQL Databases',
+		action: 'List all MySQL databases',
+		description: 'Get a list of all MySQL databases in a project',
+	})
+	.withProperties({
+		project: projectProperty,
+	})
+	.withExecuteFn(async (context) => {
+		const { properties, apiClient } = context;
+		const { project } = properties;
+
+		return apiClient.request({
+			path: `/projects/${project}/mysql-databases`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Database/operations/mysqlVersions.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/mysqlVersions.ts
@@ -1,0 +1,17 @@
+import { databaseResource } from '../resource';
+
+export default databaseResource
+	.addOperation({
+		name: 'List MySQL Versions',
+		action: 'List MySQL versions',
+		description: 'Get a list of available MySQL versions',
+	})
+	.withProperties({})
+	.withExecuteFn(async (context) => {
+		const { apiClient } = context;
+
+		return apiClient.request({
+			path: `/mysql-versions`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/Database/operations/redisVersions.ts
+++ b/nodes/Mittwald/resources/implementations/Database/operations/redisVersions.ts
@@ -1,0 +1,17 @@
+import { databaseResource } from '../resource';
+
+export default databaseResource
+	.addOperation({
+		name: 'List Redis Versions',
+		action: 'List Redis versions',
+		description: 'Get a list of available Redis versions',
+	})
+	.withProperties({})
+	.withExecuteFn(async (context) => {
+		const { apiClient } = context;
+
+		return apiClient.request({
+			path: `/redis-versions`,
+			method: 'GET',
+		});
+	});

--- a/nodes/Mittwald/resources/implementations/shared/mysqlVersionProperty.ts
+++ b/nodes/Mittwald/resources/implementations/shared/mysqlVersionProperty.ts
@@ -1,0 +1,41 @@
+import { ApiClient } from '../../../api';
+import type { OperationPropertyConfig } from '../../base';
+
+export default {
+	displayName: 'MySQL Version',
+	type: 'resourceLocator',
+	default: '',
+	searchListMethodName: 'listMySqlVersions',
+	async searchListMethod(this, filter) {
+		interface MySqlVersion {
+			id: string;
+			name: string;
+			disabled: boolean;
+			number: string;
+		}
+
+		const apiClient = new ApiClient(this);
+
+		const versions = await apiClient.request<Array<MySqlVersion>>({
+			path: `/mysql-versions`,
+			method: 'GET',
+		});
+
+		const enabledVersions = versions.filter((v) => !v.disabled);
+
+		const filteredVersions = filter
+			? enabledVersions.filter(
+					(v) =>
+						v.name.toLowerCase().includes(filter.toLowerCase()) ||
+						v.id.toLowerCase().includes(filter.toLowerCase()),
+				)
+			: enabledVersions;
+
+		return {
+			results: filteredVersions.map((version) => ({
+				name: version.name,
+				value: version.number,
+			})),
+		};
+	},
+} satisfies OperationPropertyConfig;

--- a/test/integration/database.mysql.lifecycle.test.ts
+++ b/test/integration/database.mysql.lifecycle.test.ts
@@ -62,6 +62,25 @@ integrationDescribe('Database / MySQL Lifecycle (integration)', () => {
 					parameters: { mysqlDatabaseId: fromStep('Create MySQL Database') },
 				})
 				.step({
+					name: 'Copy MySQL Database',
+					resource: 'Database',
+					operation: 'Copy MySQL Database',
+					parameters: {
+						mysqlDatabaseId: fromStep('Create MySQL Database'),
+						description: `${dbDescription}-copy`,
+						userPassword: password,
+						userAccessLevel: 'full',
+						userExternalAccess: false,
+						userDescription: `${dbDescription}-copy`,
+					},
+				})
+				.step({
+					name: 'List After Copy',
+					resource: 'Database',
+					operation: 'List MySQL Databases',
+					parameters: { project: fromStep('Create Project') },
+				})
+				.step({
 					name: 'Delete MySQL Database',
 					resource: 'Database',
 					operation: 'Delete MySQL Database',
@@ -70,11 +89,16 @@ integrationDescribe('Database / MySQL Lifecycle (integration)', () => {
 				.run();
 
 			const dbId = result.step('Create MySQL Database').requireString('id');
+			const copyId = result.step('Copy MySQL Database').requireString('id');
 
 			expect(result.step('List MySQL Databases').stringValues('id')).toContain(dbId);
 			expect(result.step('Get MySQL Database').requireString('id')).toBe(dbId);
+			expect(copyId).not.toBe(dbId);
+			expect(result.step('List After Copy').stringValues('id')).toEqual(
+				expect.arrayContaining([dbId, copyId]),
+			);
 		},
-		120_000,
+		180_000,
 	);
 
 	testcase('lists available MySQL versions', async ({ runOperation }) => {

--- a/test/integration/database.mysql.lifecycle.test.ts
+++ b/test/integration/database.mysql.lifecycle.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @n8n/community-nodes/no-restricted-imports */
+import { expect } from 'vitest';
+import { fromStep, runId } from './helpers';
+import { integrationDescribe, testcase } from './testcase';
+
+integrationDescribe('Database / MySQL Lifecycle (integration)', () => {
+	testcase(
+		'creates, lists, gets, and deletes a MySQL database in one workflow',
+		async (context) => {
+			const projectDescription = `it-${runId('mysql-project')}`;
+			const dbDescription = `it-${runId('mysql-db')}`;
+			const password = `S3cure!${runId('pw')}`;
+
+			context.teardown(async () => {
+				const response = await context.mittwaldApi.project.listProjects();
+				if (response.status !== 200) {
+					throw new Error(`Failed to list projects during teardown: ${response.statusText}`);
+				}
+				const project = response.data.find((entry) => entry.description === projectDescription);
+				if (project) {
+					await context.mittwaldApi.project.deleteProject({ projectId: project.id });
+				}
+			});
+
+			const result = await context
+				.scenario('MySQL lifecycle')
+				.step({
+					name: 'Create Project',
+					resource: 'Project',
+					operation: 'Create',
+					parameters: {
+						server: { mode: 'id', value: context.env.testServerId },
+						description: projectDescription,
+					},
+				})
+				.step({
+					name: 'Create MySQL Database',
+					resource: 'Database',
+					operation: 'Create MySQL Database',
+					parameters: {
+						project: fromStep('Create Project'),
+						description: dbDescription,
+						version: { mode: 'id', value: '8.0' },
+						characterSet: 'utf8mb4',
+						collation: 'utf8mb4_unicode_ci',
+						userPassword: password,
+						userAccessLevel: 'full',
+						userExternalAccess: false,
+						userDescription: dbDescription,
+					},
+				})
+				.step({
+					name: 'List MySQL Databases',
+					resource: 'Database',
+					operation: 'List MySQL Databases',
+					parameters: { project: fromStep('Create Project') },
+				})
+				.step({
+					name: 'Get MySQL Database',
+					resource: 'Database',
+					operation: 'Get MySQL Database',
+					parameters: { mysqlDatabaseId: fromStep('Create MySQL Database') },
+				})
+				.step({
+					name: 'Delete MySQL Database',
+					resource: 'Database',
+					operation: 'Delete MySQL Database',
+					parameters: { mysqlDatabaseId: fromStep('Create MySQL Database') },
+				})
+				.run();
+
+			const dbId = result.step('Create MySQL Database').requireString('id');
+
+			expect(result.step('List MySQL Databases').stringValues('id')).toContain(dbId);
+			expect(result.step('Get MySQL Database').requireString('id')).toBe(dbId);
+		},
+		120_000,
+	);
+
+	testcase('lists available MySQL versions', async ({ runOperation }) => {
+		const result = await runOperation({
+			resource: 'Database',
+			operation: 'List MySQL Versions',
+		});
+
+		expect(Array.isArray(result.items)).toBe(true);
+		expect(result.items.length).toBeGreaterThan(0);
+	});
+
+	testcase('lists available Redis versions', async ({ runOperation }) => {
+		const result = await runOperation({
+			resource: 'Database',
+			operation: 'List Redis Versions',
+		});
+
+		expect(Array.isArray(result.items)).toBe(true);
+		expect(result.items.length).toBeGreaterThan(0);
+	});
+});

--- a/test/integration/database.mysql.lifecycle.test.ts
+++ b/test/integration/database.mysql.lifecycle.test.ts
@@ -59,19 +59,17 @@ integrationDescribe('Database / MySQL Lifecycle (integration)', () => {
 					name: 'Get MySQL Database',
 					resource: 'Database',
 					operation: 'Get MySQL Database',
-					parameters: { mysqlDatabaseId: fromStep('Create MySQL Database') },
+					parameters: { mysqlDatabaseId: fromStep('Create MySQL Database').value },
 				})
 				.step({
 					name: 'Copy MySQL Database',
 					resource: 'Database',
 					operation: 'Copy MySQL Database',
 					parameters: {
-						mysqlDatabaseId: fromStep('Create MySQL Database'),
+						mysqlDatabaseId: fromStep('Create MySQL Database').value,
 						description: `${dbDescription}-copy`,
 						userPassword: password,
-						userAccessLevel: 'full',
 						userExternalAccess: false,
-						userDescription: `${dbDescription}-copy`,
 					},
 				})
 				.step({
@@ -84,7 +82,7 @@ integrationDescribe('Database / MySQL Lifecycle (integration)', () => {
 					name: 'Delete MySQL Database',
 					resource: 'Database',
 					operation: 'Delete MySQL Database',
-					parameters: { mysqlDatabaseId: fromStep('Create MySQL Database') },
+					parameters: { mysqlDatabaseId: fromStep('Create MySQL Database').value },
 				})
 				.run();
 


### PR DESCRIPTION
## Summary

- Adds 7 missing operations to the existing **Database** resource:
  - **Create MySQL Database** — `POST /v2/projects/{projectId}/mysql-databases` (with embedded MySQL user)
  - **List MySQL Databases** — `GET /v2/projects/{projectId}/mysql-databases`
  - **Get MySQL Database** — `GET /v2/mysql-databases/{mysqlDatabaseId}`
  - **Delete MySQL Database** — `DELETE /v2/mysql-databases/{mysqlDatabaseId}`
  - **Copy MySQL Database** — `POST /v2/mysql-databases/{mysqlDatabaseId}/actions/copy`
  - **List MySQL Versions** — `GET /v2/mysql-versions`
  - **List Redis Versions** — `GET /v2/redis-versions`
- Introduces a `mysqlVersionProperty` resourceLocator backed by the new `List MySQL Versions` endpoint.

Closes #72.

Source: route list compiled by @pellingh97.

## Test plan

- [ ] `pnpm run test:compile` passes
- [ ] `pnpm run lint` passes
- [ ] In n8n, the seven new operations appear under the **Database** resource
- [ ] `test/integration/database.mysql.lifecycle.test.ts` (create → list → get → copy → list-after-copy → delete) passes against a live API (env-gated; auto-skips otherwise) — exercises **all** seven new ops; copy verifies the new database id differs from the source and shows up in the second list

## Rebase note

This PR is part of milestone [Full mittwald API coverage](https://github.com/mittwald/n8n-nodes/milestone/1) and was opened in parallel with the other tag PRs. If another tag PR from the milestone is merged before this one, this branch will need a rebase against `master` because of additive conflicts on `nodes/Mittwald/resources/implementations/operations.ts` and `README.md`. The conflicts are mechanical (one extra import / one extra section) — GitHub may resolve them automatically via the "Update branch" button; if not, `git pull --rebase origin master` locally is enough.
